### PR TITLE
Update multimodal RAG example to use query_model input and query with text only

### DIFF
--- a/examples/08_multimodal_rag/cortex_search_multimodal.ipynb
+++ b/examples/08_multimodal_rag/cortex_search_multimodal.ipynb
@@ -442,7 +442,7 @@
     "CREATE OR REPLACE TABLE CORTEX_SEARCH_DB.PYU.DEMO_SEC_IMAGE_CORPUS AS\n",
     "SELECT\n",
     "    CONCAT('paged_image/', split_part(metadata$filename, '/', -1)) AS FILE_NAME,\n",
-    "    REGEXP_SUBSTR(metadata$filename, '_page_(\\d+)\\.', 1, 1, 'e')::INTEGER as PAGE_NUMBER,\n",
+    "    REGEXP_SUBSTR(metadata$filename, '_page_(\\\\d+)\\.', 1, 1, 'e')::INTEGER as PAGE_NUMBER,\n",
     "    '@CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL' AS STAGE_PREFIX\n",
     "FROM\n",
     "    @CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL/paged_image/\n",
@@ -465,6 +465,7 @@
     "CREATE OR REPLACE TABLE CORTEX_SEARCH_DB.PYU.DEMO_SEC_VM3_VECTORS AS\n",
     "SELECT\n",
     "    FILE_NAME,\n",
+    "    PAGE_NUMBER,\n",
     "    STAGE_PREFIX,\n",
     "    AI_EMBED(\n",
     "        'voyage-multimodal-3',\n",
@@ -503,7 +504,7 @@
     "CREATE OR REPLACE TABLE CORTEX_SEARCH_DB.PYU.DEMO_SEC_PDF_CORPUS AS\n",
     "SELECT\n",
     "    CONCAT('paged_pdf/', split_part(metadata$filename, '/', -1)) AS FILE_NAME,\n",
-    "    REGEXP_SUBSTR(metadata$filename, '_page_(\\d+)\\.', 1, 1, 'e')::INTEGER as PAGE_NUMBER,\n",
+    "    REGEXP_SUBSTR(metadata$filename, '_page_(\\\\d+)\\.', 1, 1, 'e')::INTEGER as PAGE_NUMBER,\n",
     "    '@CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL' AS STAGE_PREFIX\n",
     "FROM\n",
     "    @CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL/paged_pdf/\n",
@@ -567,7 +568,7 @@
     "\n",
     "CREATE OR REPLACE CORTEX SEARCH SERVICE CORTEX_SEARCH_DB.PYU.DEMO_SEC_CORTEX_SEARCH_SERVICE\n",
     "  TEXT INDEXES TEXT\n",
-    "  VECTOR INDEXES VECTOR_MAIN\n",
+    "  VECTOR INDEXES VECTOR_MAIN(query_model='voyage-multimodal-3')\n",
     "  WAREHOUSE='SEARCH_L'\n",
     "  TARGET_LAG='1 day'\n",
     "AS (\n",
@@ -591,7 +592,7 @@
     "name": "cell17"
    },
    "source": [
-    "We have created a multi-index Cortex Search Service with both text and vector indexes. This allows us to perform hybrid search combining keyword matching on text content and semantic similarity on vector embeddings. We'll embed queries directly with `SNOWFLAKE.CORTEX.EMBED_TEXT_1024` and use the new multi-index query syntax to search across both index types.\n",
+    "We have created a multi-index Cortex Search Service with both text and vector indexes. This allows us to perform hybrid search combining keyword matching on text content and semantic similarity on vector embeddings. We'll use the new multi-index query syntax to search across both index types.\n",
     "\n",
     "**Note:** The multi-index query syntax requires Snowflake Python API version 1.6.0 or later."
    ]
@@ -608,9 +609,7 @@
    "source": [
     "\n",
     "demo_query_text = \"What was the overall operational cost incurred by Abbott Laboratories in 2023, and how much of this amount was allocated to research and development?\"\n",
-    "sql_output = session.sql(f\"\"\"SELECT SNOWFLAKE.CORTEX.EMBED_TEXT_1024('voyage-multimodal-3', 'Represent the query for retrieving supporting documents:  {demo_query_text}')\"\"\").collect()\n",
-    "query_vector = list(sql_output[0].asDict().values())[0]\n",
-    "print(query_vector)"
+    "print(demo_query_text)"
    ]
   },
   {
@@ -626,7 +625,6 @@
    "source": [
     "from snowflake.core import Root\n",
     "\n",
-    "\n",
     "root = Root(session)\n",
     "# fetch service\n",
     "my_service = (root\n",
@@ -639,7 +637,7 @@
     "resp = my_service.search(\n",
     "    multi_index_query={\n",
     "        \"TEXT\": [{\"text\": demo_query_text}],\n",
-    "        \"VECTOR_MAIN\": [{\"vector\": query_vector}]\n",
+    "        \"VECTOR_MAIN\": [{\"text\": demo_query_text}]\n",
     "    },\n",
     "    columns=[\"TEXT\", \"PAGE_NUMBER\", \"IMAGE_FILEPATH\"],\n",
     "    limit=5\n",
@@ -679,7 +677,7 @@
    "source": [
     "session = get_active_session()\n",
     "image=session.file.get_stream(\n",
-    "    f\"@CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL/paged_image/{top_page_id}.png\",\n",
+    "    f\"@CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL/{top_page_path}\",\n",
     "    decompress=False).read()\n",
     "st.image(image)"
    ]
@@ -709,9 +707,16 @@
    },
    "outputs": [],
    "source": [
-    "SELECT SNOWFLAKE.CORTEX.COMPLETE('pixtral-large',\n",
-    "    '@CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL', '{top_page_path}',\n",
-    "    'Answer the following question by referencing the document image: What was the overall operational cost incurred by Abbott Laboratories in 2023, and how much of this amount was allocated to research and development?');"
+    "prompt = \"Answer the following question by referencing the document image {0}: What was the overall operational cost incurred by Abbott Laboratories in 2023, and how much of this amount was allocated to research and development?\"\n",
+    "query = f\"\"\"\n",
+    "    SELECT SNOWFLAKE.CORTEX.COMPLETE('pixtral-large',\n",
+    "        PROMPT('{prompt}',\n",
+    "        TO_FILE('@CORTEX_SEARCH_DB.PYU.MULTIMODAL_DEMO_INTERNAL/{top_page_path}'))\n",
+    "    );\n",
+    "\"\"\"\n",
+    "sql_output = session.sql(query).collect()\n",
+    "response = list(sql_output[0].asDict().values())[0]\n",
+    "print(response)"
    ]
   }
  ],

--- a/examples/08_multimodal_rag/streamlit_chatbot_multimodal_rag.py
+++ b/examples/08_multimodal_rag/streamlit_chatbot_multimodal_rag.py
@@ -71,18 +71,10 @@ def init_messages():
         st.session_state.messages = []
 
 def get_similar_chunks_search_service(query):
-    
-    # Embed the query using the same multimodal model used for image embeddings
-    sql_output = session.sql(f"""
-        SELECT SNOWFLAKE.CORTEX.EMBED_TEXT_1024('voyage-multimodal-3',
-        '{query.replace("'", "")}')
-    """).collect()
-    query_vector = list(sql_output[0].asDict().values())[0]
-
     response = svc.search(
         multi_index_query={
             "text": [{"text": query}],
-            "vector_main": [{"vector": query_vector}]
+            "vector_main": [{"text": query}]
         },
         columns=COLUMNS,
         limit=NUM_CHUNKS


### PR DESCRIPTION
- Update cortex search service creation to use query_model instead of embedding at query time
- Update streamlit app to use text only rather than embedding at query time
- Fix some bugs in the ipynb

This aligns with the new support for `voyage-multimodal-3` to query_model for Cortex Search multi-index.